### PR TITLE
Allow Wiremod and Seats to be destroyed

### DIFF
--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -3,8 +3,15 @@ local coltbl = coltbl or {}
 
 local affectedEnts = {}
 affectedEnts["prop_physics"] = true
-affectedEnts["gmod_wire"] = true -- gmod_wire_* --maybe i should use the first two words betweeen underlines
-affectedEnts["gmod_prisoner"] = true --gmod_prisoner_pod
+affectedEnts["gmod_prisoner_pod"] = true 
+
+function isSPDAffectedEntity(ent)
+    if affectedEnts[ent:GetClass()] or WireLib.HasPorts(ent) or ent.IsWire then
+        return true        
+    end
+    return false
+end
+
 
 local function spdEntityRemoved(ent)
 	spd[ent:EntIndex()] = nil
@@ -23,15 +30,8 @@ local function spdEntityTakeDamage(ent, dmg)
 		return
 	end
 
--- 	if ent:GetClass() ~= "prop_physics" then
--- 		return
--- 	end
-    do
-        local splitClassName = Explode("_",ent:GetClass())
-        local unsplitFirstTwo = splitClassName[1] .. "_" .. splitClassName[2]
-        if not affectedEnts[unsplitFirstTwo] then
-            return
-        end
+    if not isSPDAffectedEntity(ent) then
+        return
     end
     
 	if dmg:IsDamageType( DMG_CRUSH ) then

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -65,7 +65,8 @@ local function spdEntityTakeDamage(ent, dmg)
         return
     end
     
-    if IsSPDAffectedLOSEntity( ent ) and not isInLineOfSight( dmg:GetDamagePosition(), ent ) then
+    local condForSpecial = not isInLineOfSight( dmg:GetDamagePosition(), ent ) and dmg:IsDamageType( DMG_BLAST )
+    if IsSPDAffectedLOSEntity( ent ) and condForSpecial then
         return
     end
     

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -52,6 +52,7 @@ hook.Add("EntityRemoved", "spdEntityRemovedHook", spdEntityRemoved)
 
 local function spdEntityTakeDamage(ent, dmg)
     local entOwner = ent:CPPIGetOwner()
+    print(dmg)
 
     if not IsValid( entOwner ) then
         return

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -1,10 +1,10 @@
 local spd = spd or {}
 local coltbl = coltbl or {}
 
-local affectedEnts = {}
-affectedEnts["prop_physics"] = true
-affectedEnts["prop_vehicle_prisoner_pod"] = true 
-
+local affectedEnts = {
+    "prop_physics" = true,
+    "prop_vehicle_prisoner_pod" = true 
+}
 
 function IsSPDAffectedEntity( ent )
     if affectedEnts[ent:GetClass()] or WireLib.HasPorts( ent ) or ent.IsWire then

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -3,7 +3,7 @@ local coltbl = coltbl or {}
 
 local affectedEnts = {}
 affectedEnts["prop_physics"] = true
-affectedEnts["gmod_prisoner_pod"] = true 
+affectedEnts["prop_vehicle_prisoner_pod"] = true 
 
 
 function IsSPDAffectedEntity( ent )
@@ -16,7 +16,7 @@ function IsSPDAffectedEntity( ent )
 end
 
 function IsSPDAffectedLOSEntity( ent )
-    if ent:GetClass() == "gmod_prisoner_pod" or WireLib.HasPorts( ent ) or ent.IsWire then
+    if ent:GetClass() == "prop_vehicle_prisoner_pod" or WireLib.HasPorts( ent ) or ent.IsWire then
         
         return true        
     end

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -1,6 +1,11 @@
 local spd = spd or {}
 local coltbl = coltbl or {}
 
+local affectedEnts = {}
+affectedEnts["prop_physics"] = true
+affectedEnts["gmod_wire"] = true -- gmod_wire_* --maybe i should use the first two words betweeen underlines
+affectedEnts["gmod_prisoner"] = true --gmod_prisoner_pod
+
 local function spdEntityRemoved(ent)
 	spd[ent:EntIndex()] = nil
 	coltbl[ent:EntIndex()] = nil
@@ -18,10 +23,17 @@ local function spdEntityTakeDamage(ent, dmg)
 		return
 	end
 
-	if ent:GetClass() ~= "prop_physics" then
-		return
-	end
-
+-- 	if ent:GetClass() ~= "prop_physics" then
+-- 		return
+-- 	end
+    do
+        local splitClassName = Explode("_",ent:GetClass())
+        local unsplitFirstTwo = splitClassName[1] .. "_" .. splitClassName[2]
+        if not affectedEnts[unsplitFirstTwo] then
+            return
+        end
+    end
+    
 	if dmg:IsDamageType( DMG_CRUSH ) then
 	    local physicsDamage = GetConVar( "spd_physicsdamage" ):GetFloat()
 

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -12,6 +12,13 @@ function isSPDAffectedEntity(ent)
     return false
 end
 
+function isSPDAffectedLOSEntity(ent)
+    if ent:GetClass() == "gmod_prisoner_pod" or WireLib.HasPorts(ent) or ent.IsWire then
+        return true        
+    end
+    return false
+end
+
 local function isInLineOfSight(sVector,ent)
     local losTraceData = {}
     if not isvector(sVector) then return false end
@@ -47,6 +54,10 @@ local function spdEntityTakeDamage(ent, dmg)
 	if not isSPDAffectedEntity(ent) then
 		return
 	end
+    
+    if isSPDAffectedLOSEntity(ent) and not isInLineOfSight(dmg:GetDamagePosition(),ent) then
+        return
+    end
     
 	if dmg:IsDamageType( DMG_CRUSH ) then
 	    local physicsDamage = GetConVar( "spd_physicsdamage" ):GetFloat()
@@ -96,7 +107,7 @@ local function spdEntityTakeDamage(ent, dmg)
 	end
 	
 	if IsValid(ent) and IsValid(entPhysObj) and spd[entIndex] then
-	
+        
 		spd[entIndex] = spd[entIndex] - dmg:GetDamage() / GetConVar("spd_prophealth"):GetInt()
 		
 		local spdMaxHealth = spdGetMaxHealth(ent)

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -30,9 +30,9 @@ local function spdEntityTakeDamage(ent, dmg)
 		return
 	end
 
-    if not isSPDAffectedEntity(ent) then
-        return
-    end
+	if not isSPDAffectedEntity(ent) then
+		return
+	end
     
 	if dmg:IsDamageType( DMG_CRUSH ) then
 	    local physicsDamage = GetConVar( "spd_physicsdamage" ):GetFloat()

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -1,13 +1,14 @@
 local spd = spd or {}
 local coltbl = coltbl or {}
 
-local affectedEnts = {
-    "prop_physics" = true,
-    "prop_vehicle_prisoner_pod" = true 
-}
+local affectedEnts = {}
+affectedEnts["prop_physics"] = true
+affectedEnts["prop_vehicle_prisoner_pod"] = true 
+
 
 function IsSPDAffectedEntity( ent )
     if affectedEnts[ent:GetClass()] or WireLib.HasPorts( ent ) or ent.IsWire then
+        
         return true        
     end
     
@@ -16,6 +17,7 @@ end
 
 function IsSPDAffectedLOSEntity( ent )
     if ent:GetClass() == "prop_vehicle_prisoner_pod" or WireLib.HasPorts( ent ) or ent.IsWire then
+        
         return true        
     end
     
@@ -23,18 +25,21 @@ function IsSPDAffectedLOSEntity( ent )
 end
 
 
-local function isInLineOfSight( sVector, ent )
-    if not isvector( sVector ) then return false end
+local function isInLineOfSight( startVector, ent, damageObject )
+    if not isvector( startVector ) then return false end
+    if not damageObject:IsDamageType( DMG_BLAST ) then return false end
     
-    local entPosition = ent:GetPos() or Vector( 0, 0, 0 )
+    local entPosition = ent:GetPos()
     
-    local losTraceData = {}
-    losTraceData["start"] = sVector
-    losTraceData["endpos"] = entPosition
-    losTraceData["filter"] = ent
+    local losTraceData = {
+        "start" = startVector,
+        "endpos" = entPosition,
+        "filter" = ent
+    }
     
     local losTrace = util.TraceLine( losTraceData )
     if not losTrace.Hit then
+        
         return true
     end
     
@@ -62,7 +67,7 @@ local function spdEntityTakeDamage(ent, dmg)
         return
     end
     
-    local condForSpecial = not isInLineOfSight( dmg:GetDamagePosition(), ent ) and dmg:IsDamageType( DMG_BLAST )
+    local condForSpecial = not isInLineOfSight( dmg:GetDamagePosition(), ent, dmg )
     if IsSPDAffectedLOSEntity( ent ) and condForSpecial then
         return
     end

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -52,7 +52,6 @@ hook.Add("EntityRemoved", "spdEntityRemovedHook", spdEntityRemoved)
 
 local function spdEntityTakeDamage(ent, dmg)
     local entOwner = ent:CPPIGetOwner()
-    print(dmg)
 
     if not IsValid( entOwner ) then
         return
@@ -110,22 +109,18 @@ local function spdEntityTakeDamage(ent, dmg)
     if shouldDamage == false then return end
 
     if IsValid( ent ) and IsValid( entPhysObj ) and spd[entIndex] == nil and ent:Health() == 0 then
-
         local spdHealth = spdGetMaxHealth( ent )
         
         spd[entIndex] = spdHealth
         coltbl[entIndex] = ent:GetColor()
-        
     end
     
     if IsValid( ent ) and IsValid( entPhysObj ) and spd[entIndex] then
-        
         spd[entIndex] = spd[entIndex] - dmg:GetDamage() / GetConVar( "spd_prophealth" ):GetInt()
         
         local spdMaxHealth = spdGetMaxHealth( ent )
         
         if GetConVar( "spd_color" ):GetInt() ~= 0 then
-        
             local entHealthPercent = spd[entIndex] / spdMaxHealth
             
             local entR = coltbl[ entIndex ].r
@@ -145,33 +140,24 @@ local function spdEntityTakeDamage(ent, dmg)
             local color = Color( newR, newG, newB, alpha )
             
             ent:SetColor( color )
-            
         end
         
         if spd[entIndex] < spdMaxHealth * GetConVar( "spd_unfreeze_threshold" ):GetFloat() then
-        
             if GetConVar( "spd_effects" ):GetInt() ~= 0 then
-            
                 local effect = EffectData()
                 local dmgPos = dmg:GetDamagePosition()
                 effect:SetStart( dmgPos )
                 effect:SetOrigin( dmgPos )
                 util.Effect( cvars.String( "spd_effect" ), effect )
-                
             end
             
             if GetConVar( "spd_unfreeze" ):GetInt() ~= 0 then
-            
-                entPhysObj:EnableMotion( true )
-                
+                entPhysObj:EnableMotion( true ) 
             end
-            
         end
         
         if spd[entIndex] < spdMaxHealth * GetConVar( "spd_removeconstraints_threshold" ):GetFloat() then
-        
             if GetConVar( "spd_effects" ):GetInt() ~= 0 then
-            
                 local effect = EffectData()
                 local dmgPos = dmg:GetDamagePosition()
                 
@@ -179,21 +165,15 @@ local function spdEntityTakeDamage(ent, dmg)
                 effect:SetOrigin( dmgPos )
                 
                 util.Effect( cvars.String( "spd_effect2" ), effect )
-                
             end
             
             if GetConVarNumber( "spd_removeconstraints" ) ~= 0 then
-            
-                constraint.RemoveAll( ent )
-                
+                constraint.RemoveAll( ent ) 
             end
-            
         end
         
         if spd[entIndex] <= 0 then
-        
             if GetConVar( "spd_explosion" ):GetFloat() ~= 0 then
-            
                 local effect = EffectData()
                 local entPos = ent:WorldSpaceCenter()
                 
@@ -201,29 +181,23 @@ local function spdEntityTakeDamage(ent, dmg)
                 effect:SetOrigin( entPos )
                 
                 util.Effect( cvars.String( "spd_explosion_effect" ), effect )
-                
             end
             
             spdDebris( ent )
             
-            SafeRemoveEntity( ent )
-            
+            SafeRemoveEntity( ent ) 
         end
-        
     end
-    
 end
 
 hook.Add( "EntityTakeDamage", "spdEntityTakeDamageHook", spdEntityTakeDamage )
 
 function spdDebris( ent )
-
     if GetConVar( "spd_debris" ):GetInt() == 0 then
         return
     end
     
     if IsValid( ent ) and not ent.spdDestroyed then
-    
         ent.spdDestroyed = true
         
         local debris = ents.Create( "base_gmodentity" )
@@ -247,9 +221,7 @@ function spdDebris( ent )
         physobj:AddAngleVelocity( velVector )
         
         timer.Simple( 10, function()
-        
             if IsValid( debris ) then
-            
                 local effect = EffectData()
                 local debrisPos = debris:GetPos()
                 
@@ -258,70 +230,46 @@ function spdDebris( ent )
                 effect:SetEntity( debris )
 
                 util.Effect( "entity_remove", effect )
-                
             end
             
             timer.Simple( engine.TickInterval(), function()
-            
                 SafeRemoveEntity( debris )
-                
             end)
-            
         end)
-        
     end
-
 end
 
 function spdGetColor( ent )
-
     return coltbl[ent:EntIndex()]
-
 end
 
 function spdEnable( ent )
-
     if IsValid( ent ) then
-    
         ent.spdDisabled = false
-        
     end
-
 end
 
 function spdDisable( ent )
-    
     ent.spdDisabled = nil
-
 end
 
 function spdClear( ent )
-
     spd[ent:EntIndex()] = nil
     coltbl[ent:EntIndex()] = nil
-
 end
 
 function spdGetHealth( ent )
-
     return spd[ent:EntIndex()]
-
 end
 
 function spdGetMaxHealth( ent )
-
     return spdGetWeightHealth( ent ) + spdGetVolumeHealth( ent )
-
 end
 
 function spdGetWeightHealth( ent )
-
     return ent:GetPhysicsObject():GetMass() * GetConVar( "spd_health_weightratio" ):GetFloat()
-
 end
 
 function spdGetVolumeHealth( ent )
-
     return ent:GetPhysicsObject():GetVolume() / 500 * GetConVar( "spd_health_volumeratio" ):GetFloat()
-
 end

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -12,6 +12,20 @@ function isSPDAffectedEntity(ent)
     return false
 end
 
+local function isInLineOfSight(sVector,ent)
+    local losTraceData = {}
+    if not isvector(sVector) then return false end
+    local entPosition = ent:GetPos() or Vector(0,0,0)
+    losTraceData["start"] = sVector
+    losTraceData["endpos"] = entPosition
+    losTraceData["filter"] = ent
+    local losTrace = util.TraceLine(losTraceData)
+    if not losTrace[Hit] then
+        return true
+    end
+    return false
+end
+
 
 local function spdEntityRemoved(ent)
 	spd[ent:EntIndex()] = nil

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -36,7 +36,7 @@ local function isInLineOfSight( sVector, ent )
     losTraceData["filter"] = ent
     
     local losTrace = util.TraceLine( losTraceData )
-    if not losTrace[Hit] then
+    if not losTrace.Hit then
         
         return true
     end

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -8,7 +8,6 @@ local affectedEnts = {
 
 function IsSPDAffectedEntity( ent )
     if affectedEnts[ent:GetClass()] or WireLib.HasPorts( ent ) or ent.IsWire then
-        
         return true        
     end
     
@@ -17,7 +16,6 @@ end
 
 function IsSPDAffectedLOSEntity( ent )
     if ent:GetClass() == "prop_vehicle_prisoner_pod" or WireLib.HasPorts( ent ) or ent.IsWire then
-        
         return true        
     end
     
@@ -37,7 +35,6 @@ local function isInLineOfSight( sVector, ent )
     
     local losTrace = util.TraceLine( losTraceData )
     if not losTrace.Hit then
-        
         return true
     end
     

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -61,11 +61,11 @@ local function spdEntityTakeDamage(ent, dmg)
         return
     end
 
-    if not isSPDAffectedEntity( ent ) then
+    if not IsSPDAffectedEntity( ent ) then
         return
     end
     
-    if isSPDAffectedLOSEntity( ent ) and not isInLineOfSight( dmg:GetDamagePosition(), ent ) then
+    if IsSPDAffectedLOSEntity( ent ) and not isInLineOfSight( dmg:GetDamagePosition(), ent ) then
         return
     end
     

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -27,7 +27,7 @@ end
 
 local function isInLineOfSight( startVector, ent, damageObject )
     if not isvector( startVector ) then return false end
-    if not damageObject:IsDamageType( DMG_BLAST ) then return false end
+    if not damageObject:IsDamageType( DMG_BLAST ) then return true end
     
     local entPosition = ent:GetPos()
     

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -5,297 +5,321 @@ local affectedEnts = {}
 affectedEnts["prop_physics"] = true
 affectedEnts["gmod_prisoner_pod"] = true 
 
-function isSPDAffectedEntity(ent)
-    if affectedEnts[ent:GetClass()] or WireLib.HasPorts(ent) or ent.IsWire then
+
+function IsSPDAffectedEntity( ent )
+    if affectedEnts[ent:GetClass()] or WireLib.HasPorts( ent ) or ent.IsWire then
+        
         return true        
     end
+    
     return false
 end
 
-function isSPDAffectedLOSEntity(ent)
-    if ent:GetClass() == "gmod_prisoner_pod" or WireLib.HasPorts(ent) or ent.IsWire then
+function IsSPDAffectedLOSEntity( ent )
+    if ent:GetClass() == "gmod_prisoner_pod" or WireLib.HasPorts( ent ) or ent.IsWire then
+        
         return true        
     end
+    
     return false
 end
 
-local function isInLineOfSight(sVector,ent)
+
+local function isInLineOfSight( sVector, ent )
+    if not isvector( sVector ) then return false end
+    
+    local entPosition = ent:GetPos() or Vector( 0, 0, 0 )
+    
     local losTraceData = {}
-    if not isvector(sVector) then return false end
-    local entPosition = ent:GetPos() or Vector(0,0,0)
     losTraceData["start"] = sVector
     losTraceData["endpos"] = entPosition
     losTraceData["filter"] = ent
-    local losTrace = util.TraceLine(losTraceData)
+    
+    local losTrace = util.TraceLine( losTraceData )
     if not losTrace[Hit] then
+        
         return true
     end
+    
     return false
 end
 
-
-local function spdEntityRemoved(ent)
-	spd[ent:EntIndex()] = nil
-	coltbl[ent:EntIndex()] = nil
+local function spdEntityRemoved( ent )
+    spd[ent:EntIndex()] = nil
+    coltbl[ent:EntIndex()] = nil
 end
 hook.Add("EntityRemoved", "spdEntityRemovedHook", spdEntityRemoved)
 
 local function spdEntityTakeDamage(ent, dmg)
-	local entOwner = ent:CPPIGetOwner()
+    local entOwner = ent:CPPIGetOwner()
 
-	if not IsValid( entOwner ) then
-		return
-	end
+    if not IsValid( entOwner ) then
+        return
+    end
 
-	if GetConVar("spd_enabled"):GetInt() == 0 then
-		return
-	end
+    if GetConVar( "spd_enabled" ):GetInt() == 0 then
+        return
+    end
 
-	if not isSPDAffectedEntity(ent) then
-		return
-	end
-    
-    if isSPDAffectedLOSEntity(ent) and not isInLineOfSight(dmg:GetDamagePosition(),ent) then
+    if not isSPDAffectedEntity( ent ) then
         return
     end
     
-	if dmg:IsDamageType( DMG_CRUSH ) then
-	    local physicsDamage = GetConVar( "spd_physicsdamage" ):GetFloat()
+    if isSPDAffectedLOSEntity( ent ) and not isInLineOfSight( dmg:GetDamagePosition(), ent ) then
+        return
+    end
+    
+    if dmg:IsDamageType( DMG_CRUSH ) then
+        local physicsDamage = GetConVar( "spd_physicsdamage" ):GetFloat()
 
-	    if physicsDamage == 0 then return end
+        if physicsDamage == 0 then return end
 
-	    dmg:ScaleDamage( physicsDamage )
-	end
+        dmg:ScaleDamage( physicsDamage )
+    end
 
-	if dmg:IsDamageType( DMG_BULLET ) then
-	    local bulletDamage = GetConVar( "spd_bulletdamage" ):GetFloat()
+    if dmg:IsDamageType( DMG_BULLET ) then
+        local bulletDamage = GetConVar( "spd_bulletdamage" ):GetFloat()
 
-	    if bulletDamage == 0 then return end
+        if bulletDamage == 0 then return end
 
-	    dmg:ScaleDamage( bulletDamage )
-	end
+        dmg:ScaleDamage( bulletDamage )
+    end
 
-	if dmg:IsDamageType( DMG_BLAST ) then
-        local explosionDamage = GetConVar("spd_explosiondamage"):GetFloat()
+    if dmg:IsDamageType( DMG_BLAST ) then
+        local explosionDamage = GetConVar( "spd_explosiondamage" ):GetFloat()
 
         if explosionDamage == 0 then return end
 
         dmg:ScaleDamage( explosionDamage )
-	end
+    end
 
-	if dmg:IsDamageType( DMG_CLUB ) then
-        local meleeDamage = GetConVar("spd_meleedamage"):GetFloat()
+    if dmg:IsDamageType( DMG_CLUB ) then
+        local meleeDamage = GetConVar( "spd_meleedamage" ):GetFloat()
 
         if meleeDamage == 0 then return end
 
         dmg:ScaleDamage( meleeDamage )
-	end
+    end
 
-	local entPhysObj = ent:GetPhysicsObject()
-	local entIndex = ent:EntIndex()
+    local entPhysObj = ent:GetPhysicsObject()
+    local entIndex = ent:EntIndex()
 
-	local shouldDamage = hook.Run( "SPDEntityTakeDamage", ent, dmg )
-	if shouldDamage == false then return end
+    local shouldDamage = hook.Run( "SPDEntityTakeDamage", ent, dmg )
+    if shouldDamage == false then return end
 
-	if IsValid(ent) and IsValid(entPhysObj) and spd[entIndex] == nil and ent:Health() == 0 then
+    if IsValid( ent ) and IsValid( entPhysObj ) and spd[entIndex] == nil and ent:Health() == 0 then
 
-		local spdHealth = spdGetMaxHealth(ent)
-		
-		spd[entIndex] = spdHealth
-		coltbl[entIndex] = ent:GetColor()
-		
-	end
-	
-	if IsValid(ent) and IsValid(entPhysObj) and spd[entIndex] then
+        local spdHealth = spdGetMaxHealth( ent )
         
-		spd[entIndex] = spd[entIndex] - dmg:GetDamage() / GetConVar("spd_prophealth"):GetInt()
-		
-		local spdMaxHealth = spdGetMaxHealth(ent)
-		
-		if GetConVar("spd_color"):GetInt() ~= 0 then
-		
-			local entHealthPercent = spd[entIndex] / spdMaxHealth
-			local entR = coltbl[entIndex].r
-			local entG = coltbl[entIndex].g
-			local entB = coltbl[entIndex].b
-			local fadeR = GetConVar("spd_colorfade_r"):GetInt()
-			local fadeG = GetConVar("spd_colorfade_g"):GetInt()
-			local fadeB = GetConVar("spd_colorfade_b"):GetInt()
-			local newR = Lerp(entHealthPercent, fadeR, entR)
-			local newG = Lerp(entHealthPercent, fadeG, entG)
-			local newB = Lerp(entHealthPercent, fadeB, entB)
-			local alpha = coltbl[entIndex].a
-			local color = Color(newR, newG, newB, alpha)
-			
-			ent:SetColor(color)
-			
-		end
-		
-		if spd[entIndex] < spdMaxHealth * GetConVar("spd_unfreeze_threshold"):GetFloat() then
-		
-			if GetConVar("spd_effects"):GetInt() ~= 0 then
-			
-				local effect = EffectData()
-				local dmgPos = dmg:GetDamagePosition()
-				effect:SetStart(dmgPos)
-				effect:SetOrigin(dmgPos)
-				util.Effect(cvars.String("spd_effect"), effect)
-				
-			end
-			
-			if GetConVar("spd_unfreeze"):GetInt() ~= 0 then
-			
-				entPhysObj:EnableMotion(true)
-				
-			end
-			
-		end
-		
-		if spd[entIndex] < spdMaxHealth * GetConVar("spd_removeconstraints_threshold"):GetFloat() then
-		
-			if GetConVar("spd_effects"):GetInt() ~= 0 then
-			
-				local effect = EffectData()
-				local dmgPos = dmg:GetDamagePosition()
-				effect:SetStart(dmgPos)
-				effect:SetOrigin(dmgPos)
-				util.Effect(cvars.String("spd_effect2"), effect)
-				
-			end
-			
-			if GetConVarNumber("spd_removeconstraints") ~= 0 then
-			
-				constraint.RemoveAll(ent)
-				
-			end
-			
-		end
-		
-		if spd[entIndex] <= 0 then
-		
-			if GetConVar("spd_explosion"):GetFloat() ~= 0 then
-			
-				local effect = EffectData()
-				local entPos = ent:WorldSpaceCenter()
-				effect:SetStart(entPos)
-				effect:SetOrigin(entPos)
-				util.Effect(cvars.String("spd_explosion_effect"), effect)
-				
-			end
-			
-			spdDebris(ent)
-			
-			SafeRemoveEntity(ent)
-			
-		end
-		
-	end
-	
+        spd[entIndex] = spdHealth
+        coltbl[entIndex] = ent:GetColor()
+        
+    end
+    
+    if IsValid( ent ) and IsValid( entPhysObj ) and spd[entIndex] then
+        
+        spd[entIndex] = spd[entIndex] - dmg:GetDamage() / GetConVar( "spd_prophealth" ):GetInt()
+        
+        local spdMaxHealth = spdGetMaxHealth( ent )
+        
+        if GetConVar( "spd_color" ):GetInt() ~= 0 then
+        
+            local entHealthPercent = spd[entIndex] / spdMaxHealth
+            
+            local entR = coltbl[ entIndex ].r
+            local entG = coltbl[ entIndex ].g
+            local entB = coltbl[ entIndex ].b
+            
+            local fadeR = GetConVar( "spd_colorfade_r" ):GetInt()
+            local fadeG = GetConVar( "spd_colorfade_g" ):GetInt()
+            local fadeB = GetConVar( "spd_colorfade_b" ):GetInt()
+            
+            local newR = Lerp( entHealthPercent, fadeR, entR )
+            local newG = Lerp( entHealthPercent, fadeG, entG )
+            local newB = Lerp( entHealthPercent, fadeB, entB )
+            
+            local alpha = coltbl[entIndex].a
+            
+            local color = Color( newR, newG, newB, alpha )
+            
+            ent:SetColor( color )
+            
+        end
+        
+        if spd[entIndex] < spdMaxHealth * GetConVar( "spd_unfreeze_threshold" ):GetFloat() then
+        
+            if GetConVar( "spd_effects" ):GetInt() ~= 0 then
+            
+                local effect = EffectData()
+                local dmgPos = dmg:GetDamagePosition()
+                effect:SetStart( dmgPos )
+                effect:SetOrigin( dmgPos )
+                util.Effect( cvars.String( "spd_effect" ), effect )
+                
+            end
+            
+            if GetConVar( "spd_unfreeze" ):GetInt() ~= 0 then
+            
+                entPhysObj:EnableMotion( true )
+                
+            end
+            
+        end
+        
+        if spd[entIndex] < spdMaxHealth * GetConVar( "spd_removeconstraints_threshold" ):GetFloat() then
+        
+            if GetConVar( "spd_effects" ):GetInt() ~= 0 then
+            
+                local effect = EffectData()
+                local dmgPos = dmg:GetDamagePosition()
+                
+                effect:SetStart( dmgPos )
+                effect:SetOrigin( dmgPos )
+                
+                util.Effect( cvars.String( "spd_effect2" ), effect )
+                
+            end
+            
+            if GetConVarNumber( "spd_removeconstraints" ) ~= 0 then
+            
+                constraint.RemoveAll( ent )
+                
+            end
+            
+        end
+        
+        if spd[entIndex] <= 0 then
+        
+            if GetConVar( "spd_explosion" ):GetFloat() ~= 0 then
+            
+                local effect = EffectData()
+                local entPos = ent:WorldSpaceCenter()
+                
+                effect:SetStart( entPos )
+                effect:SetOrigin( entPos )
+                
+                util.Effect( cvars.String( "spd_explosion_effect" ), effect )
+                
+            end
+            
+            spdDebris( ent )
+            
+            SafeRemoveEntity( ent )
+            
+        end
+        
+    end
+    
 end
 
-hook.Add("EntityTakeDamage", "spdEntityTakeDamageHook", spdEntityTakeDamage)
+hook.Add( "EntityTakeDamage", "spdEntityTakeDamageHook", spdEntityTakeDamage )
 
-function spdDebris(ent)
+function spdDebris( ent )
 
-	if GetConVar("spd_debris"):GetInt() == 0 then
-		return
-	end
-	
-	if IsValid(ent) and not ent.spdDestroyed then
-	
-		ent.spdDestroyed = true
-		
-		local debris = ents.Create("base_gmodentity")
-		local mat = "debris/debris" .. tostring(math.random(1, 4))
-		
-		debris:SetPos(ent:GetPos())
-		debris:SetAngles(ent:GetAngles())
-		debris:SetModel(ent:GetModel())
-		debris:SetMaterial(mat, false)
-		debris:SetCollisionGroup(COLLISION_GROUP_WORLD)
-		debris:PhysicsInit(SOLID_VPHYSICS)
-		
-		local physobj = debris:GetPhysicsObject()
-		--local force = spdGetMaxHealth(ent) * 4
-		local force = 1000
-		
-		physobj:AddVelocity(Vector(math.random(-force, force), math.random(-force, force), math.random(-force, force)))
-		physobj:AddAngleVelocity(Vector(math.random(-force, force), math.random(-force, force), math.random(-force, force)))
-		
-		timer.Simple(10, function()
-		
-			if IsValid(debris) then
-			
-				local effect = EffectData()
-				local debrisPos = debris:GetPos()
-				effect:SetStart(debrisPos)
-				effect:SetOrigin(debrisPos)
-				effect:SetEntity(debris)
-				util.Effect("entity_remove", effect)
-				
-			end
-			
-			timer.Simple(engine.TickInterval(), function()
-			
-				SafeRemoveEntity(debris)
-				
-			end)
-			
-		end)
-		
-	end
+    if GetConVar( "spd_debris" ):GetInt() == 0 then
+        return
+    end
+    
+    if IsValid( ent ) and not ent.spdDestroyed then
+    
+        ent.spdDestroyed = true
+        
+        local debris = ents.Create( "base_gmodentity" )
+        local mat = "debris/debris" .. tostring( math.random( 1, 4 ) )
+        
+        debris:SetPos( ent:GetPos() )
+        debris:SetAngles( ent:GetAngles() )
+        debris:SetModel( ent:GetModel() )
+        debris:SetMaterial( mat, false )
+        debris:SetCollisionGroup( COLLISION_GROUP_WORLD )
+        debris:PhysicsInit( SOLID_VPHYSICS )
+        
+        local physobj = debris:GetPhysicsObject()
+        --local force = spdGetMaxHealth(ent) * 4
+        local force = 1000
+        
+        local function randForceSymmetric() return math.random( -force, force) end
+        local velVector = Vector( randForceSymmetric(), randForceSymmetric(), randForceSymmetric() )
+        
+        physobj:AddVelocity( velVector )
+        physobj:AddAngleVelocity( velVector )
+        
+        timer.Simple( 10, function()
+        
+            if IsValid( debris ) then
+            
+                local effect = EffectData()
+                local debrisPos = debris:GetPos()
+                
+                effect:SetStart( debrisPos )
+                effect:SetOrigin( debrisPos )
+                effect:SetEntity( debris )
 
-end
-
-function spdGetColor(ent)
-
-	return coltbl[ent:EntIndex()]
-
-end
-
-function spdEnable(ent)
-
-	if IsValid(ent) then
-	
-		ent.spdDisabled = false
-		
-	end
-
-end
-
-function spdDisable(ent)
-	
-	ent.spdDisabled = nil
-
-end
-
-function spdClear(ent)
-
-	spd[ent:EntIndex()] = nil
-	coltbl[ent:EntIndex()] = nil
+                util.Effect( "entity_remove", effect )
+                
+            end
+            
+            timer.Simple( engine.TickInterval(), function()
+            
+                SafeRemoveEntity( debris )
+                
+            end)
+            
+        end)
+        
+    end
 
 end
 
-function spdGetHealth(ent)
+function spdGetColor( ent )
 
-	return spd[ent:EntIndex()]
-
-end
-
-function spdGetMaxHealth(ent)
-
-	return spdGetWeightHealth(ent) + spdGetVolumeHealth(ent)
+    return coltbl[ent:EntIndex()]
 
 end
 
-function spdGetWeightHealth(ent)
+function spdEnable( ent )
 
-	return ent:GetPhysicsObject():GetMass() * GetConVar("spd_health_weightratio"):GetFloat()
+    if IsValid( ent ) then
+    
+        ent.spdDisabled = false
+        
+    end
 
 end
 
-function spdGetVolumeHealth(ent)
+function spdDisable( ent )
+    
+    ent.spdDisabled = nil
 
-	return ent:GetPhysicsObject():GetVolume() / 500 * GetConVar("spd_health_volumeratio"):GetFloat()
+end
+
+function spdClear( ent )
+
+    spd[ent:EntIndex()] = nil
+    coltbl[ent:EntIndex()] = nil
+
+end
+
+function spdGetHealth( ent )
+
+    return spd[ent:EntIndex()]
+
+end
+
+function spdGetMaxHealth( ent )
+
+    return spdGetWeightHealth( ent ) + spdGetVolumeHealth( ent )
+
+end
+
+function spdGetWeightHealth( ent )
+
+    return ent:GetPhysicsObject():GetMass() * GetConVar( "spd_health_weightratio" ):GetFloat()
+
+end
+
+function spdGetVolumeHealth( ent )
+
+    return ent:GetPhysicsObject():GetVolume() / 500 * GetConVar( "spd_health_volumeratio" ):GetFloat()
 
 end


### PR DESCRIPTION
On CFC, (deadly) contraptions like tanks, planes, turrets, etc, usually rely on chairs and/or wiremod components like gates or e2, SPD was not able to destroy these important parts of these contraptions. This PR changes it so that wiremod entities and seats are able to be destroyed either via bullets, or if an explosion has line of sight to the chair or wiremod entity. Having the explosion only be able to affect the chair or entity if it has line of sight is important, as if we just plopped in the ability to destroy them without such, an explosion outside of a tank would kill them. 
This new added ability will also be able to help in the future, if infantry weapons are able to penetrate and explode within a tank, (which i have an idea for but is out of the scope of this PR), it would be able to de-brain a tank, and forcing the builder to actually not splerg the brains onto the base prop, and actually put it somewhere protected.

In testing this, we have found a slight issue with chairs in general, as shooting them does not pulse the "EntityTakeDamage" hook, so shooting chairs doesn't really make them take damage, and explosions usually work on most chairs. This is most likely a GMod bug or chairs being cursed. Although this slight issue does not affect much, as if you're able to directly shoot a chair, you are able to kill the driver.
CC @Deconkle @hexwolf (whoever he may be)