### PR TITLE
Fix heal and toggle tools

### DIFF
--- a/lua/weapons/gmod_tool/stools/spd_heal.lua
+++ b/lua/weapons/gmod_tool/stools/spd_heal.lua
@@ -24,7 +24,10 @@ function TOOL:LeftClick(trace)
 	local owner = self:GetOwner()
 	local ent = trace.Entity
 	
-	if GetConVar("spd_tool_heal_adminonly"):GetInt() ~= 0 and owner:IsAdmin() == false then
+	local adminOnly = GetConVar("spd_tool_heal_adminonly")
+	adminOnly = adminOnly and adminOnly:GetInt() ~= 0
+
+	if adminOnly and owner:IsAdmin() == false then
 	
 		if CLIENT then
 		

--- a/lua/weapons/gmod_tool/stools/spd_toggle.lua
+++ b/lua/weapons/gmod_tool/stools/spd_toggle.lua
@@ -24,7 +24,10 @@ function TOOL:LeftClick(trace)
 	local owner = self:GetOwner()
 	local ent = trace.Entity
 	
-	if GetConVar("spd_tool_toggle_adminonly"):GetInt() ~= 0 and owner:IsAdmin() == false then
+	local adminOnly = GetConVar("spd_tool_toggle_adminonly")
+	adminOnly = adminOnly and adminOnly:GetInt() ~= 0
+
+	if adminOnly and owner:IsAdmin() == false then
 		
 		if CLIENT then
 		


### PR DESCRIPTION
`GetConVar` will return `nil` if it isn't set, so we need to handle situations where it's not set (there are plenty of more places where we need to do this, but these are among the most pressing)