### PR TITLE
Add 3D2D Textscreens to the SPD immune list

### DIFF
--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -45,7 +45,7 @@ local immuneEntities = {
     prop_vehicle_prisoner_pod = true,
     phys_spring = true,
     m9k_nervegasnade = true,
-    sammyservers_textscreen = true,
+    sammyservers_textscreen = true
 }
 
 local spdEnabled

--- a/lua/spd/server/sv_spd.lua
+++ b/lua/spd/server/sv_spd.lua
@@ -44,7 +44,8 @@ local immuneEntities = {
     gmod_sent_vehicle_fphysics_attachment = true,
     prop_vehicle_prisoner_pod = true,
     phys_spring = true,
-    m9k_nervegasnade = true
+    m9k_nervegasnade = true,
+    sammyservers_textscreen = true,
 }
 
 local spdEnabled


### PR DESCRIPTION
3D2D textscreens are owned by the player, letting them take SPD damage, but they refuse to have their weight changed. This causes all 3D2D textscreens to have next to no SPD health, getting destroyed instantly by everything.