### PR TITLE
Add max health for breakable system

### DIFF
--- a/lua/autorun/server/sv_spd.lua
+++ b/lua/autorun/server/sv_spd.lua
@@ -38,6 +38,7 @@ local cvartbl = cvartbl or {
     spd_meleedamage = 1,
     spd_frozenmodifier = 0.5,
     spd_health_max = 75000,
+    spd_health_max_destructible = 100,
 }
 
 for cvar, default in pairs( cvartbl ) do


### PR DESCRIPTION
When entities exceed the "spd_health_max_destructible" convar value the props will start using SPD instead of gmod health system. Without this pr it first allows the health of the entity to get to 0 and then start doing SPD health after it, great for breakable props not so good for custom entities. 